### PR TITLE
Fix log output for MaxDepth tests

### DIFF
--- a/LeetCodeKotlin/TestsRunner.kt
+++ b/LeetCodeKotlin/TestsRunner.kt
@@ -31,7 +31,7 @@ object TestsRunner {
         testMaximumAverageSubarrayI_643()
         println("Running InvertBinaryTree_226 tests:")
         testInvertBinaryTree_226()
-        println("Running MaximumDepthOfBinaryTree_194 tests:")
+        println("Running MaximumDepthOfBinaryTree_104 tests:")
         testMaximumDepthOfBinaryTree_104()
         println("Running BalancedBinaryTree_110 tests:")
         testBalancedBinaryTree_110()


### PR DESCRIPTION
## Summary
- correct the test runner log for MaximumDepthOfBinaryTree

## Testing
- `kotlinc *.kt -include-runtime -d .vscode/TestsRunner.jar` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f5fd9e6ec8321bc35db613dd5d46f